### PR TITLE
Update end-to-end example instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Below, we outline how to run a single mallet model on some example data.
 After installing `poetry` and miniconda (see above), clone the repo, create the environment and install the packages.
 
 ```console
-$ git clone git@github.com:ahoho/topics.git --recurse-submodules
+$ git clone https://github.com/ahoho/topics.git --recurse-submodules
 $ conda create -n soup-nuts python=3.9
 $ conda activate soup-nuts
 $ poetry install --extras gensim


### PR DESCRIPTION
cloning the repo with "https://github.com/ahoho/topics.git" is much more universal instead of git@ - where a user will likely run into issues of access esp. on remote server, from what I understand. Using the https link is more likely to work for anyone who wants to use the code for their end-to-end thing.